### PR TITLE
Update Quay.io image publishing guide

### DIFF
--- a/ci/publishing-images.md
+++ b/ci/publishing-images.md
@@ -68,6 +68,8 @@ The above also requires a `version.json` file in the directory of your code. The
 
 From there, you can follow our [standard Pull Request](/contrib/) process to get your workflow added to the repo.
 
+:mag: For security purposes, GitHub does not make secrets accessible to forked repositories. It will therefore not be possible to test workflow code in the context of a Pull Request if the workflow uses secrets. However, you can test the workflow in your own fork by creating the necessary secrets in your forked repo pointing to your own personal registry.
+
 ## Add Pre-merge (Pull Request) testing of your image
 
 For images that can be built and tested in a standard Docker environment, we can add a second workflow to run those tests.

--- a/ci/publishing-images.md
+++ b/ci/publishing-images.md
@@ -9,62 +9,62 @@ Many of our repositories, such as [Containers-Quickstarts](https://github.com/re
 In order to publish images to Quay.io, you'll need the following set up ahead of time:
 
 * A new repository and robot account created in Quay.io, set as a Secret on your repo. You can [open an issue with the CoP Tooling team](https://github.com/redhat-cop/org/issues/new?assignees=&labels=integrations&template=integrations.md&title=) to have this created.
-  * QUAY_USERNAME
-  * QUAY_PASSWORD
+  * REGISTRY_URI: quay.io
+  * REGISTRY_REPOSITORY: redhat-cop
+  * REGISTRY_USERNAME
+  * REGISTRY_PASSWORD
 
 ## Setting up a GitHub Actions Workflow to Publish an Image on Push/Merge
 
 We use [GitHub Actions](https://github.com/features/actions) for many continuous integration needs, including publishing images. To get started, create a new YAML file in your repo at `.github/workflows/`. The name of the file doesn't matter, but would typically be something like `workflow.yaml`, `main.yaml` or specifically `publish-image.yaml`.
 
-The contents of the file should look like this:
+The contents of the file should look like this (this is an example for our rabbitmq image):
 
 ```
 {% raw %}
-name: myimage-publish-workflow
+name: rabbitmq-publish
 on:
   push:
     branches:
-    # Build latest off of master
-    - master
+      - master
     tags:
-    # Version tag glob match, start 'v' then a number followed by anything
-    - 'v[0-9]*'
+      - '*'
+    paths:
+      - rabbitmq/version.json
 jobs:
   build:
-    # Only build on redhat-cop repo, do not attempt to build on forks
-    if: github.repository == 'redhat-cop/myrepo'
+    env:
+      context: rabbitmq
+      image_name: rabbitmq
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - name: Get image tags
-      id: image_tags
-      run: |
-        echo -n ::set-output name=IMAGE_TAGS::
-        # Tags build from master as latest
-        if [ "${GITHUB_REF}" == 'refs/heads/master' ]; then
-            echo latest
-        # Match git tags to image tags
-        elif [ "${GITHUB_REF:0:10}" == 'refs/tags/' ]; then
-            echo "${GITHUB_REF:10}"
-        # Otherwise, best guess... branch name
-        else
-            echo "${GITHUB_REF/*\//}"
-        fi
-    - name: Build and publish image to Quay
-      uses: elgohr/Publish-Docker-Github-Action@master
-      with:
-        # If quay.io image repository name matches github repository name, then
-        # we can just use the variable, otherwise the name will need to be set
-        # explicitly.
-        name: ${{ github.repository }}
-        username: ${{ secrets.QUAY_USERNAME }}
-        password: ${{ secrets.QUAY_PASSWORD }}
-        registry: quay.io
-        tags: ${{ steps.image_tags.outputs.IMAGE_TAGS }}
-        dockerfile: build/path/Dockerfile
-        context: build/path
+      - uses: actions/checkout@master
+      - name: Get image tags
+        id: image_tags
+        run: |
+          echo -n ::set-output name=IMAGE_TAGS::
+          VERSION=$(jq -r '.version' ${context}/version.json)
+          TAGS=('latest')
+          if [ "${VERSION}" ] && [ "${VERSION}" != "latest" ]; then
+              TAGS+=("${VERSION}")
+          fi
+          if [[ "${GITHUB_REF}" =~ refs/tags/(.*) ]]; then
+              TAGS+=("git-${BASH_REMATCH[1]}")
+          fi
+          ( IFS=$','; echo "${TAGS[*]}" )
+      - name: Build and publish image to Quay
+        uses: docker/build-push-action@v1
+        with:
+          path: ${{ env.context }}
+          registry: ${{ secrets.REGISTRY_URI }}
+          repository: ${{ secrets.REGISTRY_REPOSITORY }}/${{ env.image_name }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+          tags: "${{ steps.image_tags.outputs.IMAGE_TAGS }}"
 {% endraw %}
 ```
+
+The above also requires a `version.json` file in the directory of you code. The content is very simple, `{"version":"v1.0.0"}` and will be used to tag the image. With this file you can tag your image independently of tags on the repository. This can be convenient when you are building multiple images from the same repo, such as containers-quickstarts.
 
 From there, you can follow our [standard Pull Request](/contrib/) process to get your workflow added to the repo.
 
@@ -75,20 +75,35 @@ For images that can be built and tested in a standard Docker environment, we can
 Add another workflow file to `.github/workflows/` that looks like the following:
 
 ```
-name: myimage-test
-on: [pull_request, push]
+name: rabbitmq-pr
+on:
+  pull_request:
+    paths:
+      - rabbitmq/**
 jobs:
   build:
+    env:
+      context: rabbitmq
+      image_name: rabbitmq
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - name: Build image and test that it is functional
-      run: |
-        docker build -f container-images/myimage/Dockerfile -t myimage .
-        docker run -p 54321:54321 myimage
-
-        # Include validation steps
-        curl http://127.0.0.1:54321
+      - uses: actions/checkout@v1
+      - name: Check and verify version.json
+        id: check_version
+        run: |
+          echo -n ::set-output name=IMAGE_TAGS::
+          echo $(jq -r '.version' ${context}/version.json)
+      - name: Build image
+        uses: docker/build-push-action@v1
+        with:
+          path: ${{ env.context }}
+          push: false
+          repository: ${{ env.image_name }}
+          tags: ${{ steps.check_version.outputs.IMAGE_TAGS }}
+      - name: Test image
+        run: |
+          echo "Running: docker run --entrypoint 'rabbitmqctl' ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} 'version'"
+          docker run --entrypoint 'rabbitmqctl' ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} 'version'
 ```
 
 From there, you can follow our [standard Pull Request](/contrib/) process to get your workflow added to the repo.

--- a/ci/publishing-images.md
+++ b/ci/publishing-images.md
@@ -68,7 +68,8 @@ The above also requires a `version.json` file in the directory of your code. The
 
 From there, you can follow our [standard Pull Request](/contrib/) process to get your workflow added to the repo.
 
-:mag: For security purposes, GitHub does not make secrets accessible to forked repositories. It will therefore not be possible to test workflow code in the context of a Pull Request if the workflow uses secrets. However, you can test the workflow in your own fork by creating the necessary secrets in your forked repo pointing to your own personal registry.
+>:mag: **NOTE**<br />
+>For security purposes, GitHub does not make secrets accessible to forked repositories. It will therefore not be possible to test workflow code in the context of a Pull Request if the workflow uses secrets. However, you can test the workflow in your own fork by creating the necessary secrets in your forked repo pointing to your own personal registry.
 
 ## Add Pre-merge (Pull Request) testing of your image
 


### PR DESCRIPTION
Updated guide using Docker GH action and how to publish multiple images from a monorepo